### PR TITLE
Use system time as started time

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -287,7 +287,7 @@ func WithActivityTask(
 	client *WorkflowClient,
 ) (context.Context, error) {
 	scheduled := task.GetScheduledTime().AsTime()
-	started := task.GetStartedTime().AsTime()
+	started := time.Now()
 	scheduleToCloseTimeout := task.GetScheduleToCloseTimeout().AsDuration()
 	startToCloseTimeout := task.GetStartToCloseTimeout().AsDuration()
 	heartbeatTimeout := task.GetHeartbeatTimeout().AsDuration()


### PR DESCRIPTION
## issue: 1930 [Have implicit activity context timeout start-to-close be relative to system time not server time](https://github.com/temporalio/sdk-go/issues/1930)
## Changes: Use system time as started time